### PR TITLE
Add submodule connection to latest commit on backend repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cohabit-server"]
+	path = backend
+	url = git@github.com:r800360/cohabit-server.git


### PR DESCRIPTION
This PR uses Git Submodules to create a reference to the backend repository. It is important to recognize that this reference is _locked by commit_, meaning if a new commit is made to the `main` branch of the backend repository in the future, we must intervene to "update" the reference in this repository.