### PR TITLE
Put Firebase API keys into the project (they are not secret)

### DIFF
--- a/app/(account)/sign-in.tsx
+++ b/app/(account)/sign-in.tsx
@@ -62,7 +62,7 @@ export default function SignIn() {
       if (!cred.user.emailVerified) {
         throw new Error("You must verify your email before using this app! Please check your inbox.");
       }
-
+      router.replace("/(tabs)/main");
     } catch (fail) {
       setError(fail);
     }

--- a/app/(account)/sign-in.tsx
+++ b/app/(account)/sign-in.tsx
@@ -62,7 +62,7 @@ export default function SignIn() {
       if (!cred.user.emailVerified) {
         throw new Error("You must verify your email before using this app! Please check your inbox.");
       }
-      router.replace("/(tabs)/main");
+
     } catch (fail) {
       setError(fail);
     }

--- a/config/firebaseConfig.ts
+++ b/config/firebaseConfig.ts
@@ -1,9 +1,18 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
-import 'dotenv/config';
 
 // Initialize Firebase
-const firebaseConfig = JSON.parse(process.env["FIREBASE_CLIENT_OPTIONS"]!);
+const firebaseConfig = {
+  // https://firebase.google.com/support/guides/security-checklist#understand-api-keys
+  // "API keys for Firebase services are not secret"
+  apiKey: "AIzaSyBar6IBdWQWBHn-FOIS_oVrrCssN8vcDDA",
+  authDomain: "cohabit-app-1fb32.firebaseapp.com",
+  projectId: "cohabit-app-1fb32",
+  storageBucket: "cohabit-app-1fb32.firebasestorage.app",
+  messagingSenderId: "884027047581",
+  appId: "1:884027047581:web:62e3362afb734206185e74",
+  measurementId: "G-ETX9KB9R90"
+};
 
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/react": "~18.3.18",
     "@types/react-native": "^0.72.8",
     "@types/react-test-renderer": "^18.3.1",
-    "dotenv": "^16.4.7",
     "eslint": "^9.20.1",
     "eslint-config-expo": "canary",
     "eslint-plugin-react": "^7.37.4",


### PR DESCRIPTION
This PR removes the reference to a secret environment variable for Firebase API keys and replaces them with the API keys themselves. According to [Firebase](https://firebase.google.com/support/guides/security-checklist), these keys are not considered secret, though GitHub's automated secret scanning service might complain.