### PR TITLE
Removes codebreaking redundant lines in the babel configuration

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -3,16 +3,22 @@ module.exports = function (api) {
   return {
     presets: [
       "babel-preset-expo",
-      "@babel/preset-env",
-      "@babel/preset-react",
-      "@babel/preset-typescript"
+      "@babel/preset-typescript",
+    ],
+    plugins: [
+      ["@babel/plugin-transform-class-properties", { loose: true }],
+      ["@babel/plugin-transform-private-methods", { loose: true }],
+      ["@babel/plugin-transform-private-property-in-object", { loose: true }],
     ],
     env: {
       test: {
-        presets: [
-          ["@babel/preset-env", { targets: { node: "current" } }]
-        ]
-      }
-    }
+        presets: [["@babel/preset-env", { targets: { node: "current" } }]],
+        plugins: [
+          ["@babel/plugin-transform-class-properties", { loose: true }],
+          ["@babel/plugin-transform-private-methods", { loose: true }],
+          ["@babel/plugin-transform-private-property-in-object", { loose: true }],
+        ],
+      },
+    },
   };
 };


### PR DESCRIPTION
Removes extra setup lines from the babel configuration that were responsible for codebreaking issues and adds loose configuration settings to prevent other import issues (referenceerror property 'react' doesn't exist) and export issues ([Compiling js failed, export declaration must be at top level of module](https://stackoverflow.com/questions/77959679/compiling-js-failed-export-declaration-must-be-at-top-level-of-module)). Addresses the following issue caused by babel config:

![image](https://github.com/user-attachments/assets/f9b62794-1e3a-4cea-bb22-615f97590b31)
